### PR TITLE
Add new Oj parser into benchmark

### DIFF
--- a/benchmark/parser.rb
+++ b/benchmark/parser.rb
@@ -23,6 +23,7 @@ def benchmark_parsing(name, json_output)
     x.report("json")      { JSON.parse(json_output) } if RUN[:json]
     x.report("oj")        { Oj.load(json_output) } if RUN[:oj]
     x.report("oj strict") { Oj.strict_load(json_output) } if RUN[:oj]
+    x.report("Oj::Parser") { Oj::Parser.usual.parse(json_output) } if RUN[:oj]
     x.report("fast_jsonparser") { FastJsonparser.parse(json_output) } if RUN[:fast_jsonparser]
     x.report("rapidjson") { RapidJSON.parse(json_output) } if RUN[:rapidjson]
   end


### PR DESCRIPTION
Since oj v3.13.0, new parser `Oj::Parser` has been added.

Ref. https://github.com/ohler55/oj/blob/develop/CHANGELOG.md#3130---2021-08-08