### PR TITLE
Raise an error if trying to serialize NaN or Infinity

### DIFF
--- a/ext/rapidjson/encoder.hh
+++ b/ext/rapidjson/encoder.hh
@@ -77,7 +77,13 @@ class RubyObjectEncoder {
 
     void encode_float(VALUE v) {
         double f = rb_float_value(v);
-        writer.Double(f);
+        if (isinf(f)) {
+            rb_raise(rb_eEncodeError, "Float::INFINITY is not allowed in JSON");
+        } else if (isnan(f)) {
+            rb_raise(rb_eEncodeError, "Float::NAN is not allowed in JSON");
+        } else {
+            writer.Double(f);
+        }
     }
 
     void encode_string(VALUE v) {

--- a/test/test_encoder.rb
+++ b/test/test_encoder.rb
@@ -119,4 +119,23 @@ class TestEncoder < Minitest::Test
   def test_encode_nil
     assert_equal "null", encode(nil)
   end
+
+  def test_encode_NaN
+    error = assert_raises RapidJSON::EncodeError do
+      encode(Float::NAN)
+    end
+    assert_match "Float::NAN is not allowed in JSON", error.message
+  end
+
+  def test_encode_Infinity
+    error = assert_raises RapidJSON::EncodeError do
+      encode(Float::INFINITY)
+    end
+    assert_match "Float::INFINITY is not allowed in JSON", error.message
+
+    error = assert_raises RapidJSON::EncodeError do
+      encode(-Float::INFINITY)
+    end
+    assert_match "Float::INFINITY is not allowed in JSON", error.message
+  end
 end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -78,4 +78,14 @@ class TestParser < Minitest::Test
       assert parse("["*(max+1) + "]"*(max+1))
     end
   end
+
+  def test_parse_NaN_and_Infinity
+    assert_raises RapidJSON::ParseError do
+      parse("NaN")
+    end
+
+    assert_raises RapidJSON::ParseError do
+      parse("Infinity")
+    end
+  end
 end


### PR DESCRIPTION
It's debatable whether they should be supported. They are not valid JSON according to RFC8259, however the stdlib JSON does parse them by default and has an option not to.

RapidJSON also has a flag to parse them, but it's not set by this gem.

So I think this gem should either parse and generate them, or fail to do both, but right now it won't parse them but will hapilly generated broken JSON when encoding them.