### PR TITLE
WIP faster hash building

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,14 @@ GEM
   remote: https://rubygems.org/
   specs:
     benchmark-ips (2.10.0)
-    fast_jsonparser (0.5.0)
-    json (2.6.1)
-    minitest (5.15.0)
-    oj (3.13.11)
+    fast_jsonparser (0.6.0)
+    json (2.6.3)
+    minitest (5.17.0)
+    oj (3.13.23)
     rake (13.0.6)
-    rake-compiler (1.1.9)
+    rake-compiler (1.2.1)
       rake
-    yajl-ruby (1.4.1)
+    yajl-ruby (1.4.3)
 
 PLATFORMS
   ruby

--- a/benchmark/parser.rb
+++ b/benchmark/parser.rb
@@ -19,13 +19,17 @@ def benchmark_parsing(name, json_output)
   puts "== Parsing #{name} (#{json_output.size} bytes)"
 
   Benchmark.ips do |x|
-    x.report("yajl")      { Yajl::Parser.new.parse(json_output) } if RUN[:yajl]
+    x.config quiet: true if ENV["QUIET"]
+
     x.report("json")      { JSON.parse(json_output) } if RUN[:json]
+    x.report("yajl")      { Yajl::Parser.new.parse(json_output) } if RUN[:yajl]
     x.report("oj")        { Oj.load(json_output) } if RUN[:oj]
     x.report("oj strict") { Oj.strict_load(json_output) } if RUN[:oj]
     x.report("Oj::Parser") { Oj::Parser.usual.parse(json_output) } if RUN[:oj]
     x.report("fast_jsonparser") { FastJsonparser.parse(json_output) } if RUN[:fast_jsonparser]
     x.report("rapidjson") { RapidJSON.parse(json_output) } if RUN[:rapidjson]
+
+    x.compare!
   end
   puts
 end


### PR DESCRIPTION
WIP

It's faster to buffer items in a (C) array before creating a hash from them. Partly because this avoids the cost in Ruby of building a `ar_table` before it is converted to an `st_table` once the hash goes beyond 8 elements.

I don't believe this has been tested sufficiently yet.