### PR TITLE
Handle serializing integers larger than 64bits.

### DIFF
--- a/test/test_encoder.rb
+++ b/test/test_encoder.rb
@@ -33,6 +33,10 @@ class TestEncoder < Minitest::Test
     assert_equal "18446744073709551615", encode(2**64 - 1)
   end
 
+  def test_encore_arbitrary_size_num
+    assert_equal "340282366920938463463374607431768211456", encode(2**128)
+  end
+
   def test_encode_fixnum_exponents
     tests = []
     0.upto(65) do |exponent|


### PR DESCRIPTION
BigNum are expected to be rare, so calling `Integer#to_s` while not super fast is fast enough and simpler than checking bounds.

Ref: https://github.com/jhawthorn/rapidjson-ruby/pull/4

This only does the serialization part as it doesn't really have downsides. For the parsing part, we'll have to see if my patch is accepted upstream etc.