### PR TITLE
Refactor handling of non-native types 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,7 @@ jobs:
         bundler-cache: true
     - name: Run the default task
       run: bundle exec rake
+    - name: Run against stdlib JSON
+      run: bundle exec rake
+      env:
+        TEST_JSON: "1"

--- a/benchmark/encoder.rb
+++ b/benchmark/encoder.rb
@@ -33,3 +33,4 @@ benchmark_encoding "small hash", { "username" => "jhawthorn", "id" => 123, "even
 benchmark_encoding "twitter.json", JSON.load_file("#{__dir__}/../test/data/twitter.json")
 benchmark_encoding "citm_catalog.json", JSON.load_file("#{__dir__}/../test/data/citm_catalog.json")
 benchmark_encoding "canada.json", JSON.load_file("#{__dir__}/../test/data/canada.json")
+benchmark_encoding "many #to_json calls", [{Object.new => Object.new, 12 => 54.3, Integer => Float, Time.now => Date.today}] * 20

--- a/ext/rapidjson/buffer.hh
+++ b/ext/rapidjson/buffer.hh
@@ -8,6 +8,7 @@ class RubyStringBuffer {
 
         RubyStringBuffer() : used(0), capacity(INITIAL_SIZE) {
             ruby_string = rb_str_buf_new(INITIAL_SIZE);
+            rb_enc_associate(ruby_string, rb_utf8_encoding());
             mem = RSTRING_PTR(ruby_string);
         }
 

--- a/ext/rapidjson/cext.cc
+++ b/ext/rapidjson/cext.cc
@@ -6,9 +6,9 @@
 
 static VALUE rb_eParseError;
 static VALUE rb_eEncodeError;
+static VALUE rb_cRapidJSONFragment;
 
-static ID id_to_json;
-static ID id_to_s;
+static ID id_call;
 
 #include "encoder.hh"
 #include "parser.hh"
@@ -18,19 +18,19 @@ using namespace rapidjson;
 typedef RubyStringBuffer DefaultBuffer;
 
 static VALUE
-encode(VALUE _self, VALUE obj) {
-    RubyObjectEncoder<DefaultBuffer, Writer<DefaultBuffer> > encoder;
-    return encoder.encode(obj);
+dump(VALUE _self, VALUE obj, VALUE pretty, VALUE as_json) {
+    // NB: as_json here is not marked by the extension, but is always on the stack
+    if (RTEST(pretty)) {
+        RubyObjectEncoder<DefaultBuffer, PrettyWriter<DefaultBuffer> > encoder(as_json);
+        return encoder.encode(obj);
+    } else {
+        RubyObjectEncoder<DefaultBuffer, Writer<DefaultBuffer> > encoder(as_json);
+        return encoder.encode(obj);
+    }
 }
 
 static VALUE
-pretty_encode(VALUE _self, VALUE obj) {
-    RubyObjectEncoder<DefaultBuffer, PrettyWriter<DefaultBuffer> > encoder;
-    return encoder.encode(obj);
-}
-
-static VALUE
-parse(VALUE _self, VALUE string) {
+load(VALUE _self, VALUE string) {
     RubyObjectHandler handler;
     Reader reader;
     char *cstring = StringValueCStr(string); // fixme?
@@ -63,17 +63,16 @@ valid_json_p(VALUE _self, VALUE string) {
 extern "C" void
 Init_rapidjson(void)
 {
-    id_to_s = rb_intern("to_s");
-    id_to_json = rb_intern("to_json");
+    id_call = rb_intern("call");
 
     VALUE rb_mRapidJSON = rb_const_get(rb_cObject, rb_intern("RapidJSON"));
-    rb_define_module_function(rb_mRapidJSON, "encode", encode, 1);
-    rb_define_module_function(rb_mRapidJSON, "pretty_encode", pretty_encode, 1);
-    rb_define_module_function(rb_mRapidJSON, "dump", encode, 1);
+    VALUE rb_cCoder = rb_const_get(rb_mRapidJSON, rb_intern("Coder"));
+    rb_cRapidJSONFragment = rb_const_get(rb_mRapidJSON, rb_intern("Fragment"));;
+    rb_global_variable(&rb_cRapidJSONFragment);
 
-    rb_define_module_function(rb_mRapidJSON, "parse", parse, 1);
-    rb_define_module_function(rb_mRapidJSON, "load", parse, 1);
-    rb_define_module_function(rb_mRapidJSON, "valid_json?", valid_json_p, 1);
+    rb_define_private_method(rb_cCoder, "_dump", dump, 3);
+    rb_define_method(rb_cCoder, "load", load, 1);
+    rb_define_method(rb_cCoder, "valid_json?", valid_json_p, 1);
 
     VALUE rb_eRapidJSONError = rb_const_get(rb_mRapidJSON, rb_intern("Error"));
     rb_eParseError = rb_define_class_under(rb_mRapidJSON, "ParseError", rb_eRapidJSONError);

--- a/ext/rapidjson/cext.cc
+++ b/ext/rapidjson/cext.cc
@@ -4,7 +4,6 @@
 #include "rapidjson/prettywriter.h"
 #include "rapidjson/error/en.h"
 
-static VALUE rb_mRapidJSON;
 static VALUE rb_eParseError;
 static VALUE rb_eEncodeError;
 
@@ -67,7 +66,7 @@ Init_rapidjson(void)
     id_to_s = rb_intern("to_s");
     id_to_json = rb_intern("to_json");
 
-    rb_mRapidJSON = rb_define_module("RapidJSON");
+    VALUE rb_mRapidJSON = rb_const_get(rb_cObject, rb_intern("RapidJSON"));
     rb_define_module_function(rb_mRapidJSON, "encode", encode, 1);
     rb_define_module_function(rb_mRapidJSON, "pretty_encode", pretty_encode, 1);
     rb_define_module_function(rb_mRapidJSON, "dump", encode, 1);
@@ -76,6 +75,7 @@ Init_rapidjson(void)
     rb_define_module_function(rb_mRapidJSON, "load", parse, 1);
     rb_define_module_function(rb_mRapidJSON, "valid_json?", valid_json_p, 1);
 
-    rb_eParseError = rb_define_class_under(rb_mRapidJSON, "ParseError", rb_eStandardError);
-    rb_eEncodeError = rb_define_class_under(rb_mRapidJSON, "EncodeError", rb_eStandardError);
+    VALUE rb_eRapidJSONError = rb_const_get(rb_mRapidJSON, rb_intern("Error"));
+    rb_eParseError = rb_define_class_under(rb_mRapidJSON, "ParseError", rb_eRapidJSONError);
+    rb_eEncodeError = rb_define_class_under(rb_mRapidJSON, "EncodeError", rb_eRapidJSONError);
 }

--- a/ext/rapidjson/encoder.hh
+++ b/ext/rapidjson/encoder.hh
@@ -93,7 +93,7 @@ class RubyObjectEncoder {
         const char *cstr = RSTRING_PTR(s);
         size_t len = RSTRING_LEN(s);
 
-	writer.RawValue(cstr, len, kObjectType);
+        writer.RawValue(cstr, len, kObjectType);
     }
 
     void encode_generic(VALUE obj) {

--- a/ext/rapidjson/encoder.hh
+++ b/ext/rapidjson/encoder.hh
@@ -9,13 +9,14 @@ template <typename B = RubyStringBuffer, typename W=Writer<B> >
 class RubyObjectEncoder {
     B buf;
     W writer;
+    VALUE as_json;
 
     void encode_array(VALUE ary) {
         writer.StartArray();
         int length = RARRAY_LEN(ary);
         RARRAY_PTR_USE(ary, ptr, {
                 for (int i = 0; i < length; i++) {
-                encode_any(ptr[i]);
+                encode_any(ptr[i], true);
                 }
                 });
         writer.EndArray();
@@ -23,19 +24,33 @@ class RubyObjectEncoder {
 
     void encode_key(VALUE key) {
         switch(rb_type(key)) {
+            case T_STRING:
+                break;
             case T_SYMBOL:
                 key = rb_sym2str(key);
-                /* FALLTHRU */
-            case T_STRING:
-                writer.Key(RSTRING_PTR(key), RSTRING_LEN(key), false);
-                return;
+                break;
+            case T_FIXNUM:
+            case T_BIGNUM:
+                key = rb_String(key);
+                break;
             default:
-                {
-                    VALUE str = rb_funcall(key, id_to_s, 0);
-                    Check_Type(str, T_STRING);
-                    encode_string(str);
+                if (NIL_P(as_json)) {
+                    rb_raise(rb_eTypeError, "Invalid object key type: %" PRIsVALUE, rb_obj_class(key));
+                    UNREACHABLE_RETURN();
                 }
+
+                key = rb_funcall(as_json, id_call, 2, key, Qtrue);
+                if (rb_obj_class(key) == rb_cRapidJSONFragment) {
+                    VALUE str = rb_struct_aref(key, INT2FIX(0));
+                    Check_Type(str, T_STRING);
+                    return encode_raw_json_str(str);
+                }
+
+                break;
         }
+
+        Check_Type(key, T_STRING);
+        writer.Key(RSTRING_PTR(key), RSTRING_LEN(key), false);
     }
 
     static int encode_hash_i_cb(VALUE key, VALUE val, VALUE ctx) {
@@ -46,7 +61,7 @@ class RubyObjectEncoder {
 
     void encode_hash_i(VALUE key, VALUE val) {
         encode_key(key);
-        encode_any(val);
+        encode_any(val, true);
     }
 
     void encode_hash(VALUE hash) {
@@ -62,7 +77,7 @@ class RubyObjectEncoder {
     void encode_bignum(VALUE b) {
         // Some T_BIGNUM might be small enough to fit in long long or unsigned long long
         // but this being the slow path, it's not really worth it.
-        VALUE str = rb_funcall(b, id_to_s, 0);
+        VALUE str = rb_String(b);
         Check_Type(str, T_STRING);
 
         // We should be able to use RawNumber here, but it's buggy
@@ -97,18 +112,15 @@ class RubyObjectEncoder {
     }
 
     void encode_generic(VALUE obj) {
-        if (rb_respond_to(obj, id_to_json)) {
-            VALUE str = rb_funcall(obj, id_to_json, 0);
-            Check_Type(str, T_STRING);
-            encode_raw_json_str(str);
-        } else {
-            VALUE str = rb_funcall(obj, id_to_s, 0);
-            Check_Type(str, T_STRING);
-            encode_string(str);
+        if (NIL_P(as_json)) {
+            rb_raise(rb_eTypeError, "Don't know how to serialize %" PRIsVALUE " to JSON", rb_obj_class(obj));
+            UNREACHABLE_RETURN();
         }
+
+        encode_any(rb_funcall(as_json, id_call, 2, obj, Qfalse), false);
     }
 
-    void encode_any(VALUE v) {
+    void encode_any(VALUE v, bool generic) {
         switch(rb_type(v)) {
             case T_NIL:
                 writer.Null();
@@ -133,19 +145,31 @@ class RubyObjectEncoder {
                 return encode_string(v);
             case T_SYMBOL:
                 return encode_symbol(v);
+            case T_STRUCT:
+                if (rb_obj_class(v) == rb_cRapidJSONFragment) {
+                    VALUE str = rb_struct_aref(v, INT2FIX(0));
+                    Check_Type(str, T_STRING);
+                    return encode_raw_json_str(str);
+                }
+                // fall through
             default:
-                encode_generic(v);
+                if (generic) {
+                    encode_generic(v);
+                } else {
+                    rb_raise(rb_eTypeError, "Don't know how to serialize %" PRIsVALUE " to JSON", rb_obj_class(v));
+                }
         }
     }
 
     public:
-        RubyObjectEncoder(): buf(), writer(buf), depth(0) {
+        RubyObjectEncoder(VALUE as_json_proc): buf(), writer(buf), depth(0) {
+            as_json = as_json_proc;
         };
 
         int depth;
 
         VALUE encode(VALUE obj) {
-            encode_any(obj);
+            encode_any(obj, true);
             return buf.GetRubyString();
         }
 };

--- a/lib/rapidjson.rb
+++ b/lib/rapidjson.rb
@@ -4,6 +4,58 @@ require_relative "rapidjson/version"
 
 module RapidJSON
   class Error < StandardError; end
+
+  Fragment = Struct.new(:to_json)
+
+  STDLIB_TO_JSON_PROC = lambda do |object, is_key|
+    if !is_key && object.respond_to?(:to_json)
+      Fragment.new(object.to_json)
+    elsif object.respond_to?(:to_s)
+      object.to_s
+    else
+      raise TypeError, "Can't serialize #{object.class} to JSON"
+    end
+  end
+  private_constant :STDLIB_TO_JSON_PROC
+
+  class Coder
+    def initialize(pretty: false, &to_json)
+      @pretty = pretty
+      @to_json_proc = to_json
+    end
+
+    def dump(object)
+      _dump(object, @pretty, @to_json_proc)
+    end
+  end
 end
 
 require_relative "rapidjson/rapidjson"
+
+module RapidJSON
+  class << self
+    def load(string)
+      DEFAULT_CODER.load(string)
+    end
+    alias_method :parse, :load
+
+    def dump(object)
+      DEFAULT_CODER.dump(object)
+    end
+    alias_method :encode, :dump
+
+    def pretty_encode(object)
+      PRETTY_CODER.encode(object)
+    end
+
+    def valid_json?(string)
+      DEFAULT_CODER.valid_json?(string)
+    end
+  end
+
+  DEFAULT_CODER = Coder.new(&STDLIB_TO_JSON_PROC)
+  private_constant :DEFAULT_CODER
+
+  PRETTY_CODER = Coder.new(pretty: true, &STDLIB_TO_JSON_PROC)
+  private_constant :PRETTY_CODER
+end

--- a/lib/rapidjson.rb
+++ b/lib/rapidjson.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require_relative "rapidjson/version"
-require_relative "rapidjson/rapidjson"
 
 module RapidJSON
   class Error < StandardError; end
-  # Your code goes here...
 end
+
+require_relative "rapidjson/rapidjson"


### PR DESCRIPTION
I believe that the flori/json behavior of calling either `to_json`
or `to_s` on unknown types is very much undesirable.

The first reason is that `Object#to_json` is defined, and fallback
as `Object#to_s`, meaning `JSON.dump()` accept absolutely anything
and will generally return valid JSON but garbage data.

I think it would be much better to explicitly define how types that
don't directly map to JSON are to be serialized.

The second reason is that `to_json` methods are global, so it's impossible
to serialize a type in one way in one part of the application, and in another
way elsewhere.

Typically you may way to serialize `Time` object in different formats when talking
to different APIs.

The solution in this PR is to provide a `Proc` to the encoder, when it
encounter an unknown type, it calls the provided proc and get either
a native type or a JSON fragment back.

This allows to both implement the `flori/json` API, but also to implement
some more restricted serialization using `case / when` or similar.

NB: Right now the PR set the stdlib behavior as the default to show it's possible to implement a behavior close enough to the stdlib to replace it. But I don't think it should remain the default behavior long term.