### PR TITLE
Stop benchmarking against fast_jsonparser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,4 @@ group :benchmark do
   gem "oj"
   gem "yajl-ruby"
   gem "json"
-  gem "fast_jsonparser"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     benchmark-ips (2.10.0)
-    fast_jsonparser (0.5.0)
     json (2.6.1)
     minitest (5.15.0)
     oj (3.13.11)
@@ -22,7 +21,6 @@ PLATFORMS
 
 DEPENDENCIES
   benchmark-ips
-  fast_jsonparser
   json
   minitest (~> 5.0)
   oj

--- a/README.md
+++ b/README.md
@@ -73,13 +73,10 @@ Many of these optimization can be found in all popular Ruby JSON libraries
                 yajl     35.510  (± 2.8%) i/s -    180.000  in   5.070803s
                 json     22.105  (± 0.0%) i/s -    112.000  in   5.067063s
                   oj     15.163  (± 6.6%) i/s -     76.000  in   5.042864s
-     fast_jsonparser     10.791  (± 0.0%) i/s -     54.000  in   5.004290s
            rapidjson    148.263  (± 2.0%) i/s -    742.000  in   5.006370s
 ```
 Notes: oj seems unusually bad at this test, and is usually faster than yajl and
 json, and comparable to rapidjson.
-`fast_jsonparser` has been slow since Ruby 3.0, likely a bug, if fixed I'd
-expect it to be the fasest JSON parser.
 
 Other libraries may include modes to avoid constructing all objects. Currently
 RapidJSON only focuses on the patterns and APIs users are likely to actually

--- a/benchmark/parser.rb
+++ b/benchmark/parser.rb
@@ -2,7 +2,6 @@ require "benchmark/ips"
 require "json"
 require "oj"
 require "yajl"
-require "fast_jsonparser"
 require "rapidjson"
 
 if ENV["ONLY"]
@@ -24,7 +23,6 @@ def benchmark_parsing(name, json_output)
     x.report("oj")        { Oj.load(json_output) } if RUN[:oj]
     x.report("oj strict") { Oj.strict_load(json_output) } if RUN[:oj]
     x.report("Oj::Parser") { Oj::Parser.usual.parse(json_output) } if RUN[:oj]
-    x.report("fast_jsonparser") { FastJsonparser.parse(json_output) } if RUN[:fast_jsonparser]
     x.report("rapidjson") { RapidJSON.parse(json_output) } if RUN[:rapidjson]
     x.compare!(order: :baseline)
   end

--- a/benchmark/validate.rb
+++ b/benchmark/validate.rb
@@ -2,7 +2,6 @@ require "benchmark/ips"
 require "json"
 require "oj"
 require "yajl"
-require "fast_jsonparser"
 require "rapidjson"
 
 if ENV["ONLY"]


### PR DESCRIPTION
It's not a serious gem, it would be a bad idea to run it in production, and it's not even fast anyway.