### PR TITLE
Replace rb_funcall with rb_proc_call_with_block

### DIFF
--- a/ext/rapidjson/cext.cc
+++ b/ext/rapidjson/cext.cc
@@ -8,8 +8,6 @@ static VALUE rb_eParseError;
 static VALUE rb_eEncodeError;
 static VALUE rb_cRapidJSONFragment;
 
-static ID id_call;
-
 #include "encoder.hh"
 #include "parser.hh"
 
@@ -63,8 +61,6 @@ valid_json_p(VALUE _self, VALUE string) {
 extern "C" void
 Init_rapidjson(void)
 {
-    id_call = rb_intern("call");
-
     VALUE rb_mRapidJSON = rb_const_get(rb_cObject, rb_intern("RapidJSON"));
     VALUE rb_cCoder = rb_const_get(rb_mRapidJSON, rb_intern("Coder"));
     rb_cRapidJSONFragment = rb_const_get(rb_mRapidJSON, rb_intern("Fragment"));;

--- a/ext/rapidjson/encoder.hh
+++ b/ext/rapidjson/encoder.hh
@@ -40,7 +40,8 @@ class RubyObjectEncoder {
                     UNREACHABLE_RETURN();
                 }
 
-                key = rb_funcall(as_json, id_call, 2, key, Qtrue);
+                VALUE args[2] = { key, Qtrue };
+                key = rb_proc_call_with_block(as_json, 2, args, Qnil);
                 if (rb_obj_class(key) == rb_cRapidJSONFragment) {
                     VALUE str = rb_struct_aref(key, INT2FIX(0));
                     Check_Type(str, T_STRING);
@@ -132,7 +133,8 @@ class RubyObjectEncoder {
             UNREACHABLE_RETURN();
         }
 
-        encode_any(rb_funcall(as_json, id_call, 2, obj, Qfalse), false);
+        VALUE args[2] = { obj, Qfalse };
+        encode_any(rb_proc_call_with_block(as_json, 2, args, Qnil), false);
     }
 
     void encode_any(VALUE v, bool generic) {


### PR DESCRIPTION
It's both a simpler API and faster:

```
Comparison:
             rb_funcall: 10986001.4 i/s
rb_proc_call_with_block: 12617549.9 i/s - 1.15x  (± 0.00) faster
```