### PR TITLE
Add RapidJSON::ActiveSupportEncoder (and json_escape)

### DIFF
--- a/ext/rapidjson/cext.cc
+++ b/ext/rapidjson/cext.cc
@@ -10,6 +10,7 @@ static VALUE rb_cRapidJSONFragment;
 
 #include "encoder.hh"
 #include "parser.hh"
+#include "json_escape.h"
 
 using namespace rapidjson;
 
@@ -73,4 +74,6 @@ Init_rapidjson(void)
     VALUE rb_eRapidJSONError = rb_const_get(rb_mRapidJSON, rb_intern("Error"));
     rb_eParseError = rb_define_class_under(rb_mRapidJSON, "ParseError", rb_eRapidJSONError);
     rb_eEncodeError = rb_define_class_under(rb_mRapidJSON, "EncodeError", rb_eRapidJSONError);
+
+    rb_define_singleton_method(rb_mRapidJSON, "json_escape", escape_json, 1);
 }

--- a/ext/rapidjson/json_escape.h
+++ b/ext/rapidjson/json_escape.h
@@ -1,0 +1,90 @@
+#include "ruby.h"
+#include "ruby/encoding.h"
+
+/* strlen("\\u2029") == 6 */
+#define ESCAPE_JSON_MAX_LEN 6
+
+static inline long
+json_escaped_length(VALUE str)
+{
+    const long len = RSTRING_LEN(str);
+    if (len >= LONG_MAX / ESCAPE_JSON_MAX_LEN) {
+        ruby_malloc_size_overflow(len, ESCAPE_JSON_MAX_LEN);
+    }
+    return len * ESCAPE_JSON_MAX_LEN;
+}
+
+static VALUE
+escape_json(VALUE self, VALUE str)
+{
+    if (!RB_TYPE_P(str, T_STRING)) {
+        str = rb_convert_type(str, T_STRING, "String", "to_s");
+    }
+
+    rb_encoding *enc = rb_enc_get(str);
+    if (enc != rb_utf8_encoding() && enc != rb_usascii_encoding()) {
+        rb_raise(rb_eEncCompatError, "input string must be UTF-8 or ASCII");
+    }
+
+    const char *cstr = RSTRING_PTR(str);
+    const unsigned long str_len = RSTRING_LEN(str);
+    const char *end = cstr + RSTRING_LEN(str);
+
+    size_t initial_match = strcspn(cstr, "&<>\xe2");
+    if (initial_match == str_len) {
+        return str;
+    }
+
+    VALUE escaped = rb_str_buf_new(json_escaped_length(str));
+    rb_str_resize(escaped, json_escaped_length(str));
+    char *buf = RSTRING_PTR(escaped);
+    char *dest = buf;
+
+    memcpy(dest, cstr, initial_match);
+    cstr += initial_match;
+    dest += initial_match;
+
+    while (cstr < end) {
+        const char c = *cstr++;
+
+#define JSON_ESCAPE_CONCAT(s) do { \
+    memcpy(dest, ("\\u" s), strlen(s) + 2); \
+    dest += strlen(s) + 2; \
+} while (0)
+
+        if (0) {
+        }
+        else if (c == '&') {
+            JSON_ESCAPE_CONCAT("0026");
+        }
+        else if (c == '>') {
+            JSON_ESCAPE_CONCAT("003e");
+        }
+        else if (c == '<') {
+            JSON_ESCAPE_CONCAT("003c");
+        }
+        else if (c == '\xe2' && cstr[0] == '\x80' && cstr[1] == '\xa8') {
+            JSON_ESCAPE_CONCAT("2028");
+            cstr += 2;
+        }
+        else if (c == '\xe2' && cstr[0] == '\x80' && cstr[1] == '\xa9') {
+            JSON_ESCAPE_CONCAT("2029");
+            cstr += 2;
+        }
+        else {
+            *dest++ = c;
+        }
+
+        initial_match = strcspn(cstr, "&<>\xe2");
+        memcpy(dest, cstr, initial_match);
+        cstr += initial_match;
+        dest += initial_match;
+
+#undef JSON_ESCAPE_CONCAT
+    }
+
+    rb_str_resize(escaped, dest - buf);
+    rb_enc_associate(escaped, rb_enc_get(str));
+
+    return escaped;
+}

--- a/lib/rapidjson.rb
+++ b/lib/rapidjson.rb
@@ -51,3 +51,4 @@ module RapidJSON
 end
 
 require "rapidjson/json_gem"
+require "rapidjson/active_support_encoder"

--- a/lib/rapidjson/active_support_encoder.rb
+++ b/lib/rapidjson/active_support_encoder.rb
@@ -1,0 +1,26 @@
+module RapidJSON
+  class ActiveSupportEncoder
+    def initialize(options = nil)
+      @options = options
+      @coder = RapidJSON::Coder.new do |value, is_key|
+        if is_key
+          value.to_s
+        else
+          value.as_json
+        end
+      end
+    end
+
+    # Encode the given object into a JSON string
+    def encode(value)
+      if @options && !@options.empty?
+        value = value.as_json(@options.dup)
+      end
+      json = @coder.dump(value)
+      if ActiveSupport::JSON::Encoding.escape_html_entities_in_json
+        json = RapidJSON.json_escape(json)
+      end
+      json
+    end
+  end
+end

--- a/lib/rapidjson/json_gem.rb
+++ b/lib/rapidjson/json_gem.rb
@@ -12,7 +12,13 @@ module RapidJSON
 
     TO_JSON_PROC = lambda do |object, is_key|
       if !is_key && object.respond_to?(:to_json)
-        Fragment.new(object.to_json(STATE))
+        if Float === object
+          # Avoid calling .to_json on NaN/Infinity/-Infinity
+          # Prefers our exception to one raised by ::JSON
+          object
+        else
+          Fragment.new(object.to_json(STATE))
+        end
       elsif object.respond_to?(:to_s)
         object.to_s
       else

--- a/test/test_active_support_encoder.rb
+++ b/test/test_active_support_encoder.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Sorry
+unless defined?(ActiveSupport::JSON::Encoding)
+  module ActiveSupport
+    module JSON
+      module Encoding
+        class << self
+          attr_accessor :escape_html_entities_in_json
+        end
+        self.escape_html_entities_in_json = false
+      end
+    end
+  end
+end
+
+class TestActiveSupportEncoder < Minitest::Test
+  class AsJSON
+    def initialize value
+      @as_json = value.freeze
+    end
+
+    def as_json(options = nil)
+      @as_json
+    end
+  end
+
+  class ReturnOptions
+    def as_json(options = nil)
+      options
+    end
+  end
+
+  class ToString
+    def initialize value
+      @to_s = value
+    end
+
+    attr_reader :to_s
+  end
+
+  def encode(value, options = nil)
+    RapidJSON::ActiveSupportEncoder.new(options).encode(value)
+  end
+
+  def test_basic_types
+    assert_equal "true", encode(true)
+    assert_equal "false", encode(false)
+    assert_equal "null", encode(nil)
+    assert_equal "1", encode(1)
+    assert_equal "2.5", encode(2.5)
+    assert_equal %q{"foo"}, encode("foo")
+
+    assert_equal "[]", encode([])
+    assert_equal %q{["foo"]}, encode(["foo"])
+    assert_equal %q{["foo"]}, encode([:foo])
+
+    assert_equal "{}", encode({})
+    assert_equal %q{{"key":"value"}}, encode({"key" => "value"})
+    assert_equal %q{{"key":"value"}}, encode({key: :value})
+
+    ex = assert_raises NoMethodError do
+      encode(BasicObject.new)
+    end
+    assert_includes ex.message, "as_json"
+  end
+
+  def test_as_json_values
+    assert_equal %q{"foo"}, encode(AsJSON.new("foo"))
+    assert_equal "null", encode(AsJSON.new(nil))
+    assert_equal "[]", encode(AsJSON.new([]))
+
+    assert_equal %q{["success"]}, encode(AsJSON.new([AsJSON.new("success")]))
+    assert_equal %q{{"success":"yes!"}}, encode(AsJSON.new({success: AsJSON.new("yes!")}))
+
+    ex = assert_raises TypeError do
+      encode(AsJSON.new(AsJSON.new("bad")))
+    end
+    assert_equal "Don't know how to serialize TestActiveSupportEncoder::AsJSON to JSON", ex.message
+  end
+
+  def test_to_s_keys
+    assert_equal %q{{"foo":"ok"}}, encode(ToString.new("foo") => "ok")
+
+    ex = assert_raises TypeError do
+      encode(ToString.new([]) => "bad")
+    end
+    assert_equal "wrong argument type Array (expected String)", ex.message
+  end
+
+  def test_options
+    assert_equal "null", encode(ReturnOptions.new)
+    assert_equal "null", encode(ReturnOptions.new, {})
+
+    assert_equal %q{{"include":"foo"}}, encode(ReturnOptions.new, { include: :foo })
+    assert_equal %q{null}, encode(AsJSON.new(ReturnOptions.new), { include: :foo })
+    assert_equal %q{[null]}, encode(AsJSON.new([ReturnOptions.new]), { include: :foo })
+  end
+end

--- a/test/test_json_escape.rb
+++ b/test/test_json_escape.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests copied from https://github.com/jhawthorn/json_escape
+# based on tests originally from Active Support
+
+module JsonEscapeTestCases
+  JSON_ESCAPE_TEST_CASES = [
+    ["1", "1"],
+    ["null", "null"],
+    ['"&"', '"\u0026"'],
+    ['"</script>"', '"\u003c/script\u003e"'],
+    ['["</script>"]', '["\u003c/script\u003e"]'],
+    ['{"name":"</script>"}', '{"name":"\u003c/script\u003e"}'],
+    [%({"name":"d\u2028h\u2029h"}), '{"name":"d\u2028h\u2029h"}']
+  ]
+
+  def test_json_escape
+    JSON_ESCAPE_TEST_CASES.each do |(raw, expected)|
+      assert_equal expected, json_escape(raw)
+    end
+  end
+
+  def test_json_escape_does_not_alter_json_string_meaning
+    JSON_ESCAPE_TEST_CASES.each do |(raw, _)|
+      expected = RapidJSON.parse(raw)
+      if expected.nil?
+        assert_nil RapidJSON.parse(json_escape(raw))
+      else
+        assert_equal expected, RapidJSON.parse(json_escape(raw))
+      end
+    end
+  end
+
+  def test_json_escape_is_idempotent
+    JSON_ESCAPE_TEST_CASES.each do |(raw, _)|
+      assert_equal json_escape(raw), json_escape(json_escape(raw))
+    end
+  end
+
+  def test_long_strings
+    [1, 2, 255, 256, 2**8, 2**16].each do |size|
+      str = "\"#{?& * size}\""
+      escaped = json_escape(str)
+      assert_equal size * 6 + 2, escaped.size
+    end
+  end
+
+  def test_incompatible_encodings
+    JSON_ESCAPE_TEST_CASES.each do |(raw, _)|
+      ex = assert_raises Encoding::CompatibilityError do
+        json_escape(raw.b)
+      end
+      assert_equal "input string must be UTF-8 or ASCII", ex.message
+    end
+  end
+end
+
+class TestJsonEscape < Minitest::Test
+  include JsonEscapeTestCases
+  def json_escape(str)
+    RapidJSON.json_escape(str)
+  end
+end


### PR DESCRIPTION
`RapidJSON::ActiveSupportEncoder` is intended to be a drop-in replacement for Active Support's JSONGemEncoder (`ActiveSupport::JSON::Encoding.json_encoder = RapidJSON::ActiveSupportEncoder`)

cc @byroot 

TODO:
* [x] How to handle `Infinity`/`NaN`
* [x] String encoding handling https://github.com/jhawthorn/rapidjson-ruby/pull/15